### PR TITLE
Uses xdg to load and save resources file

### DIFF
--- a/ryvencore_qt/__init__.py
+++ b/ryvencore_qt/__init__.py
@@ -1,10 +1,11 @@
 
 # set package path (for resources etc.)
-import os
+import pathlib
 from .src.GlobalAttributes import Location
-Location.PACKAGE_PATH = os.path.normpath(os.path.dirname(__file__))
+Location.PACKAGE_PATH = pathlib.PurePath(__file__).parent
 
 # set ryvencore gui mode
+import os
 os.environ['RC_MODE'] = 'gui'
 
 # import backend wrapper

--- a/ryvencore_qt/src/Design.py
+++ b/ryvencore_qt/src/Design.py
@@ -6,7 +6,7 @@ from qtpy.QtGui import QFontDatabase
 from .flows.FlowTheme import FlowTheme_Toy, FlowTheme_DarkTron, FlowTheme_Ghost, FlowTheme_Blender, \
     FlowTheme_Simple, FlowTheme_Ueli, FlowTheme_PureDark, FlowTheme, FlowTheme_PureLight, \
     FlowTheme_Colorful, FlowTheme_ColorfulLight, FlowTheme_Industrial, FlowTheme_Fusion
-from .GlobalAttributes import Location
+from .utils import get_resource
 
 
 class Design(QObject):
@@ -41,13 +41,13 @@ class Design(QObject):
     def register_fonts():
         db = QFontDatabase()
         db.addApplicationFont(
-            Location.PACKAGE_PATH + '/resources/fonts/poppins/Poppins-Medium.ttf'
+            get_resource('fonts/poppins/Poppins-Medium.ttf')
         )
         db.addApplicationFont(
-            Location.PACKAGE_PATH + '/resources/fonts/source_code_pro/SourceCodePro-Regular.ttf'
+            get_resource('fonts/source_code_pro/SourceCodePro-Regular.ttf')
         )
         db.addApplicationFont(
-            Location.PACKAGE_PATH + '/resources/fonts/asap/Asap-Regular.ttf'
+            get_resource('fonts/asap/Asap-Regular.ttf')
         )
 
     def register_flow_themes(self):

--- a/ryvencore_qt/src/Design.py
+++ b/ryvencore_qt/src/Design.py
@@ -41,13 +41,13 @@ class Design(QObject):
     def register_fonts():
         db = QFontDatabase()
         db.addApplicationFont(
-            get_resource('fonts/poppins/Poppins-Medium.ttf')
+            str(get_resource('fonts/poppins/Poppins-Medium.ttf'))
         )
         db.addApplicationFont(
-            get_resource('fonts/source_code_pro/SourceCodePro-Regular.ttf')
+            str(get_resource('fonts/source_code_pro/SourceCodePro-Regular.ttf'))
         )
         db.addApplicationFont(
-            get_resource('fonts/asap/Asap-Regular.ttf')
+            str(get_resource('fonts/asap/Asap-Regular.ttf'))
         )
 
     def register_flow_themes(self):

--- a/ryvencore_qt/src/conv_gui/ScriptsList_ScriptWidget.py
+++ b/ryvencore_qt/src/conv_gui/ScriptsList_ScriptWidget.py
@@ -28,7 +28,7 @@ class ScriptsList_ScriptWidget(QWidget):
 
         #   create icon
 
-        script_icon = QIcon(get_resource('pics/script_picture.png'))
+        script_icon = QIcon(str(get_resource('pics/script_picture.png')))
 
         icon_label = QLabel()
         icon_label.setFixedSize(20, 20)

--- a/ryvencore_qt/src/conv_gui/ScriptsList_ScriptWidget.py
+++ b/ryvencore_qt/src/conv_gui/ScriptsList_ScriptWidget.py
@@ -2,7 +2,7 @@ from qtpy.QtWidgets import QWidget, QHBoxLayout, QLabel, QMenu, QAction
 from qtpy.QtGui import QIcon, QImage
 from qtpy.QtCore import Qt, QEvent, QBuffer, QByteArray
 
-from ..GlobalAttributes import Location
+from ..utils import get_resource
 from .ListWidget_NameLineEdit import ListWidget_NameLineEdit
 
 
@@ -28,7 +28,7 @@ class ScriptsList_ScriptWidget(QWidget):
 
         #   create icon
 
-        script_icon = QIcon(Location.PACKAGE_PATH + '/resources/pics/script_picture.png')
+        script_icon = QIcon(get_resource('pics/script_picture.png'))
 
         icon_label = QLabel()
         icon_label.setFixedSize(20, 20)

--- a/ryvencore_qt/src/conv_gui/VarsList_VarWidget.py
+++ b/ryvencore_qt/src/conv_gui/VarsList_VarWidget.py
@@ -4,9 +4,8 @@ from qtpy.QtCore import QMimeData, Qt, QEvent, QByteArray
 
 import json
 
-from ..GlobalAttributes import Location
 from .ListWidget_NameLineEdit import ListWidget_NameLineEdit
-from ..utils import shorten
+from ..utils import shorten, get_resource
 from .EditVal_Dialog import EditVal_Dialog
 
 
@@ -31,7 +30,7 @@ class VarsList_VarWidget(QWidget):
 
         # create icon
 
-        variable_icon = QIcon(Location.PACKAGE_PATH+'/resources/pics/variable_picture.png')
+        variable_icon = QIcon(get_resource('pics/variable_picture.png'))
 
         icon_label = QLabel()
         icon_label.setFixedSize(15, 15)

--- a/ryvencore_qt/src/conv_gui/VarsList_VarWidget.py
+++ b/ryvencore_qt/src/conv_gui/VarsList_VarWidget.py
@@ -30,7 +30,7 @@ class VarsList_VarWidget(QWidget):
 
         # create icon
 
-        variable_icon = QIcon(get_resource('pics/variable_picture.png'))
+        variable_icon = QIcon(str(get_resource('pics/variable_picture.png')))
 
         icon_label = QLabel()
         icon_label.setFixedSize(15, 15)

--- a/ryvencore_qt/src/flows/nodes/NodeItem_CollapseButton.py
+++ b/ryvencore_qt/src/flows/nodes/NodeItem_CollapseButton.py
@@ -1,7 +1,6 @@
 from qtpy.QtCore import QSize, QRectF, QPointF, QSizeF, Qt
 from qtpy.QtWidgets import QGraphicsWidget, QGraphicsLayoutItem
 
-from ...GlobalAttributes import Location
 from ...utils import change_svg_color
 
 
@@ -18,9 +17,9 @@ class NodeItem_CollapseButton(QGraphicsWidget):
         self.setCursor(Qt.PointingHandCursor)
 
 
-        self.collapse_pixmap = change_svg_color(Location.PACKAGE_PATH+'/resources/node_collapse_icon.svg',
+        self.collapse_pixmap = change_svg_color('node_collapse_icon.svg',
                                                 self.node.color)
-        self.expand_pixmap = change_svg_color(Location.PACKAGE_PATH+'/resources/node_expand_icon.svg',
+        self.expand_pixmap = change_svg_color('node_expand_icon.svg',
                                               self.node.color)
 
 


### PR DESCRIPTION
I ran into the same problem as in https://github.com/leon-thomm/Ryven/issues/81#issuecomment-961348123, where the `svg` file could not be saved in the system-wide directory. Instead of making this directory writeable to everyone, I use `xdg` to save them in the correct user's home directory. As a (as I believe positive) side effect, the resources are first searched for in the user's and then the system-wide `share/ryven/` directories. As a fallback the old directory is hard coded.

I also took the liberty to use the `pathlib` library to handle paths. This should work on Linux/MacOS and Windows.