### PR TITLE
Enables automatic dpi scaling.

### DIFF
--- a/ryvencore_qt/__init__.py
+++ b/ryvencore_qt/__init__.py
@@ -6,6 +6,7 @@ Location.PACKAGE_PATH = os.path.normpath(os.path.dirname(__file__))
 
 # set ryvencore gui mode
 os.environ['RC_MODE'] = 'gui'
+os.environ['QT_ENABLE_HIGHDPI_SCALING'] = '1'
 
 # import backend wrapper
 from .src.core_wrapper import *

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ryvencore-qt
-version = v0.3.1.2
+version = v0.3.1.3
 author = Leon Thomm
 author_email = l.thomm@mailbox.org
 description = Qt frontend for ryvencore; Library for building Visual Node Editors


### PR DESCRIPTION
I have a high dpi scaling and the nodes in the main window were just tiny. According to https://doc.qt.io/qt-5/highdpi.html:

> The QT_ENABLE_HIGHDPI_SCALING environment variable, introduced in Qt 5.14, enables automatic scaling based on the pixel density of the monitor. Replaces QT_AUTO_SCREEN_SCALE_FACTOR.

This is the approach used in this PR.

Alternatives:

> The Qt::AA_EnableHighDpiScaling application attribute, introduced in Qt 5.6, enables automatic scaling based on the monitor's pixel density.