### PR TITLE
Makes theme selection caseless.

### DIFF
--- a/ryvencore_qt/src/Design.py
+++ b/ryvencore_qt/src/Design.py
@@ -99,7 +99,7 @@ class Design(QObject):
 
     def flow_theme_by_name(self, name: str) -> FlowTheme:
         for theme in self.flow_themes:
-            if theme.name == name:
+            if theme.name.casefold() == name.casefold():
                 return theme
         return None
 


### PR DESCRIPTION
Needed to enable case insensitive flow themes on the command line (see https://github.com/leon-thomm/Ryven/pull/96/commits/22816e2763d77473669f64219be0cc18b742cf9f)